### PR TITLE
Support for cargo git dependencies.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,6 @@
                 }
             },
             "args": [
-                "./system_tests/example_metric.toml",
                 "https://github.com/aunovis/secure_sum"
             ],
             "cwd": "${workspaceFolder}"


### PR DESCRIPTION
Cargo allows specifying a URL for a dependency:
```
serde = { git = "https://github.com/serde-rs/serde.git" }
toml = { git = "ssh://git@github.com/toml-rs/toml.git" }
```
This PR makes secure_sum use this URL as the target.