### PR TITLE
Add command to clear stored probe results 

### DIFF
--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -62,7 +62,9 @@ use std::fmt::Display;
 use clap::ValueEnum;
 use serde::{{Deserialize, Serialize}};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
+#[derive(
+    Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum,
+)]
 #[allow(non_camel_case_types)]
 pub(crate) enum ProbeName {{
     {probes}

--- a/scripts/generate_code.py
+++ b/scripts/generate_code.py
@@ -59,9 +59,10 @@ TEMPLATE = """
 
 use std::fmt::Display;
 
+use clap::ValueEnum;
 use serde::{{Deserialize, Serialize}};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
 #[allow(non_camel_case_types)]
 pub(crate) enum ProbeName {{
     {probes}

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+use crate::probe_name::ProbeName;
+
 #[derive(Parser)]
 #[command(version, about, long_about = None, subcommand_precedence_over_arg = true)]
 #[derive(Default)]
@@ -44,10 +46,6 @@ pub(crate) struct Arguments {
     #[arg(long, short)]
     pub(crate) timeout: Option<humantime::Duration>,
 
-    /// Get detailed information about a specific probe
-    #[arg(long, short, value_name = "PROBENAME")]
-    pub(crate) probe: Option<String>,
-
     /// Subcommands
     #[command(subcommand)]
     pub(crate) command: Option<Command>,
@@ -61,6 +59,13 @@ pub(crate) enum Command {
         /// Level of clearing.
         #[arg(value_enum, value_name = "LEVEL")]
         level: ClearLevel,
+    },
+
+    /// Get detailed information about a specific probe
+    Probe {
+        /// Name of the probe to get information about
+        #[arg(value_name = "PROBENAME")]
+        probe_name: ProbeName,
     },
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,7 +7,13 @@ use clap::{Parser, Subcommand, ValueEnum};
 use crate::probe_name::ProbeName;
 
 #[derive(Parser)]
-#[command(version, about, long_about = None, subcommand_precedence_over_arg = true)]
+#[command(
+    version,
+    about,
+    long_about = None,
+    subcommand_precedence_over_arg = true,
+    override_usage = "\n  secure_sum [FILEPATH(S)|URL(S)...] [OPTIONS]\n  secure_sum <COMMAND> [OPTIONS]"
+)]
 #[derive(Default)]
 pub(crate) struct Arguments {
     /// Path to the metric file that defines the probes to analyse
@@ -54,7 +60,10 @@ pub(crate) struct Arguments {
 #[derive(Subcommand, Clone, Debug)]
 pub(crate) enum Command {
     /// Clear stored probe results
-    #[command(visible_alias = "clean")]
+    #[command(
+        visible_alias = "clean",
+        override_usage = "\n  secure_sum clear <LEVEL> [OPTIONS]"
+    )]
     Clear {
         /// Level of clearing.
         #[arg(value_enum, value_name = "LEVEL")]
@@ -62,6 +71,7 @@ pub(crate) enum Command {
     },
 
     /// Get detailed information about a specific probe
+    #[command(override_usage = "\n  secure_sum probe <PROBENAME> [OPTIONS]")]
     Probe {
         /// Name of the probe to get information about
         #[arg(value_name = "PROBENAME")]

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,10 +2,10 @@
 
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(version, about, long_about = None, subcommand_precedence_over_arg = true)]
 #[derive(Default)]
 pub(crate) struct Arguments {
     /// Path to the metric file that defines the probes to analyse
@@ -47,4 +47,28 @@ pub(crate) struct Arguments {
     /// Get detailed information about a specific probe
     #[arg(long, short, value_name = "PROBENAME")]
     pub(crate) probe: Option<String>,
+
+    /// Subcommands
+    #[command(subcommand)]
+    pub(crate) command: Option<Command>,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub(crate) enum Command {
+    /// Clear stored probe results
+    #[command(visible_alias = "clean")]
+    Clear {
+        /// Level of clearing.
+        #[arg(value_enum, value_name = "LEVEL")]
+        level: ClearLevel,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "snake_case")]
+pub(crate) enum ClearLevel {
+    /// Clear all stored probe results
+    All,
+    /// Clear only stored probe results that contain scorecard errors
+    ErrorsOnly,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -25,11 +25,11 @@ pub(crate) struct Arguments {
     pub(crate) rerun: bool,
 
     /// Supress all output except for results and errors
-    #[arg(long, short)]
+    #[arg(long, short, global = true)]
     pub(crate) quiet: bool,
 
     /// Print a lot of detailed output
-    #[arg(long, short)]
+    #[arg(long, short, global = true)]
     pub(crate) verbose: bool,
 
     /// Overwrite the minimal score a repo must reach before an error is displayed

--- a/src/ecosystem/rust.rs
+++ b/src/ecosystem/rust.rs
@@ -38,12 +38,12 @@ impl DepFile for CargoToml {
 }
 
 fn key_val_to_target(key: &str, val: &toml::Value) -> SingleTarget {
-    if let toml::Value::Table(table) = val {
-        if let Some(toml::Value::String(git_url)) = table.get("git") {
-            let url = git_url.trim_end_matches(".git");
-            let url = url.replace("ssh://git@", "https://");
-            return SingleTarget::Url(url.into());
-        }
+    if let toml::Value::Table(table) = val
+        && let Some(toml::Value::String(git_url)) = table.get("git")
+    {
+        let url = git_url.trim_end_matches(".git");
+        let url = url.replace("ssh://git@", "https://");
+        return SingleTarget::Url(url.into());
     }
     SingleTarget::Package(key.to_owned(), Ecosystem::Rust)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use scorecard::{dispatch_scorecard_runs, ensure_scorecard_binary};
 use tabled::{Table, settings::Style};
 use target::Target;
 
-use crate::{error::Error, probe_name::ProbeName};
+use crate::error::Error;
 
 fn main() -> Result<(), Error> {
     let args = Arguments::parse();
@@ -39,9 +39,19 @@ fn main() -> Result<(), Error> {
         ));
     }
     init_logging(&args)?;
-    if let Some(Command::Clear { level }) = args.command.as_ref() {
-        return probe::clear_stored_probes(*level);
+    
+    match args.command.as_ref() {
+        Some(Command::Clear { level }) => {
+            return probe::clear_stored_probes(*level);
+        }
+        Some(Command::Probe { probe_name }) => {
+            println!("Detailed information for probe {}:", probe_name);
+            println!("{}", probe_name.get_description());
+            return Ok(());
+        }
+        None => {}
     }
+
     let metric = Metric::new(args.metric.as_deref())?;
     let targets: Vec<_> = args
         .dependencies
@@ -64,11 +74,6 @@ fn main() -> Result<(), Error> {
             repo.print_detailed_output();
         }
     }
-    if let Some(probe_name) = args.probe.as_deref().map(str::trim) {
-        let probe: ProbeName = serde_json::from_str(&format!("\"{}\"", probe_name))
-            .map_err(|_| Error::Input(format!("Unknown probe name: {}", probe_name)))?;
-        println!("Detailed information for probe {}:", probe);
-        println!("{}", probe.get_description());
-    }
+
     post_evaluate_repos(&results, &metric, &args)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Error> {
         ));
     }
     init_logging(&args)?;
-    
+
     match args.command.as_ref() {
         Some(Command::Clear { level }) => {
             return probe::clear_stored_probes(*level);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod scorecard;
 mod target;
 mod url;
 
-use args::Arguments;
+use args::{Arguments, Command};
 use clap::Parser;
 use github_token::ensure_valid_github_token;
 use logging::init_logging;
@@ -39,6 +39,9 @@ fn main() -> Result<(), Error> {
         ));
     }
     init_logging(&args)?;
+    if let Some(Command::Clear { level }) = args.command.as_ref() {
+        return probe::clear_stored_probes(*level);
+    }
     let metric = Metric::new(args.metric.as_deref())?;
     let targets: Vec<_> = args
         .dependencies

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::Error, filesystem::data_dir, metric::Metric, probe_name::ProbeName,
+    args::ClearLevel, error::Error, filesystem::data_dir, metric::Metric, probe_name::ProbeName,
     target::SingleTarget, url::Url,
 };
 
@@ -172,6 +172,44 @@ pub(crate) fn needs_rerun(stored_probe: &ProbeResult, metric: &Metric) -> bool {
     probes_to_run
         .iter()
         .any(|probe| !probe_finding_names.contains(&probe.name.to_string().as_str()))
+}
+
+pub(crate) fn clear_stored_probes(clear_level: ClearLevel) -> Result<(), Error> {
+    let probe_dir = data_dir()?.join("probes");
+    if !probe_dir.exists() || !probe_dir.is_dir() {
+        log::warn!(
+            "Unable to clear stored probes. Directory does not exist: {}",
+            probe_dir.display()
+        );
+        return Ok(());
+    }
+    match clear_level {
+        ClearLevel::All => {
+            fs::remove_dir_all(&probe_dir)?;
+            fs::create_dir_all(&probe_dir)?;
+            log::info!("Cleared all stored probes");
+        }
+        ClearLevel::ErrorsOnly => {
+            let mut num_probes_cleared = 0;
+            for probe in fs::read_dir(&probe_dir)? {
+                let path = probe?.path();
+                if path.is_file() {
+                    let contents = read_to_string(&path)?;
+                    let probe: ProbeResult = serde_json::from_str(&contents)?;
+                    if probe.scorecard_error_message.is_some() {
+                        fs::remove_file(&path)?;
+                        num_probes_cleared += 1;
+                    }
+                }
+            }
+            if num_probes_cleared == 0 {
+                log::info!("No stored probes with errors found");
+            } else {
+                log::info!("Cleared {} stored probes with errors", num_probes_cleared);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -123,10 +123,10 @@ pub(crate) fn store_probe(target: &SingleTarget, result: &ProbeResult) -> Result
 
 pub(crate) fn store_probe_json(target: &SingleTarget, raw_output: &str) -> Result<(), Error> {
     let path = probe_file(target)?;
-    if let Some(dir) = path.parent() {
-        if !dir.exists() {
-            fs::create_dir_all(dir)?;
-        }
+    if let Some(dir) = path.parent()
+        && !dir.exists()
+    {
+        fs::create_dir_all(dir)?;
     }
     log::debug!("Storing probe output in {}", path.display());
     Ok(fs::write(path, raw_output)?)

--- a/src/probe_name.rs
+++ b/src/probe_name.rs
@@ -2,9 +2,10 @@
 /// Please do not modify it directly.
 use std::fmt::Display;
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
 #[allow(non_camel_case_types)]
 pub(crate) enum ProbeName {
     archived,

--- a/src/probe_name.rs
+++ b/src/probe_name.rs
@@ -5,7 +5,9 @@ use std::fmt::Display;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
+#[derive(
+    Deserialize, Serialize, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum,
+)]
 #[allow(non_camel_case_types)]
 pub(crate) enum ProbeName {
     archived,

--- a/src/scorecard.rs
+++ b/src/scorecard.rs
@@ -105,12 +105,11 @@ fn evaluate_repo(
     force_rerun: bool,
     timeout: Option<humantime::Duration>,
 ) -> Result<ProbeResult, Error> {
-    if !force_rerun {
-        if let Some(stored_probe) = load_stored_probe(target)? {
-            if !needs_rerun(&stored_probe, metric) {
-                return Ok(stored_probe);
-            }
-        }
+    if !force_rerun
+        && let Some(stored_probe) = load_stored_probe(target)?
+        && !needs_rerun(&stored_probe, metric)
+    {
+        return Ok(stored_probe);
     }
     let timeout = timeout
         .map(|duration| time::Duration::from_secs(duration.as_secs()))

--- a/system_tests/test.sh
+++ b/system_tests/test.sh
@@ -25,7 +25,7 @@ cargo run --release -- --metric example_metric.toml rust_cargo.toml
 # Run on a dependencyfile of the Node.js ecosystem, with verbose output and radically low error thresholds
 cargo run --release -- --metric example_metric.toml node_js_package.json --verbose --error-threshold=0.1
 # Run on a project.csproj file of the NuGet ecosystem, with less output
-cargo run --release -- --metric example_metric.toml nuget_project_1.csproj --quiet -e 1.5
+cargo run --release -- --metric example_metric.toml nuget_project_1.csproj --quiet -t 7m -e 1.5
 # Run on a (somewhat old-fashioned) packages.config file of the NuGet ecosystem
 cargo run --release -- --metric example_metric.toml nuget_packages.config
 


### PR DESCRIPTION
- added subcommand `clear` (alias `clean`) with clear level as arguments `all` or `errors_only`
  - `all`: command will delete all probes in directory `AppData/Roaming/aunovis/aunovis_secure_sum/data/probes`
  - `errors_only`: command will only delete probe files that contain scorecard errors
- made options `--verbose` and `--quiet` global, so that they can also be used by subcommands
- changed type of option `--probe` to subcommand `probe`
- added usage information
  - `secure_sum [FILEPATH(S)|URL(S)...] [OPTIONS]`
  - `secure_sum <COMMAND> [OPTIONS]`
  - `secure_sum clear <LEVEL> [OPTIONS]`
  - `secure_sum probe <PROBENAME> [OPTIONS]`